### PR TITLE
Make sure that the selfsign.sh file gets dos2unix'd when the base container is building.

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -2,7 +2,10 @@ FROM amazonlinux:2
 MAINTAINER Fidelius Contributors
 
 RUN yum install -y openssl
+RUN yum install -y dos2unix
 ADD /scripts/selfsign.sh /tmp/selfsign.sh
 RUN chmod a+rx /tmp/selfsign.sh
+RUN dos2unix /tmp/selfsign.sh
+RUN yum remove -y dos2unix
 RUN /tmp/selfsign.sh
 

--- a/containers/base/scripts/selfsign.sh
+++ b/containers/base/scripts/selfsign.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 /usr/bin/openssl req -x509 -nodes -days 365 \
     -subj  "/CN=localhost" \
     -newkey rsa:2048 \


### PR DESCRIPTION
The base container needs to dos2unix the shell script for the Windows crowd, otherwise it wont work