### PR TITLE
Update the Fidelius SDK to use Default Region from local AWS Credentials instead of just us-east-1

### DIFF
--- a/fidelius-sdk/pom.xml
+++ b/fidelius-sdk/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>org.finra.fidelius</groupId>
     <artifactId>fidelius-sdk</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>fidelius-sdk</name>
     <description>SDK for Fidelius Secrets Manager</description>
@@ -72,7 +72,7 @@
     </developers>
 
     <properties>
-        <aws.version>1.11.303</aws.version>
+        <aws.version>1.11.767</aws.version>
     </properties>
 
     <dependencies>
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.54</version>
+            <version>1.65</version>
         </dependency>
 
         <dependency>

--- a/fidelius-sdk/src/main/java/org/finra/fidelius/JCredStash.java
+++ b/fidelius-sdk/src/main/java/org/finra/fidelius/JCredStash.java
@@ -19,14 +19,18 @@ package org.finra.fidelius;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
 
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.document.*;
 import com.amazonaws.services.dynamodbv2.document.spec.QuerySpec;
 import com.amazonaws.services.dynamodbv2.document.utils.NameMap;
 import com.amazonaws.services.dynamodbv2.document.utils.ValueMap;
 import com.amazonaws.services.dynamodbv2.model.*;
+import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.AWSKMSClient;
+import com.amazonaws.services.kms.AWSKMSClientBuilder;
 import com.amazonaws.services.kms.model.DecryptRequest;
 import com.amazonaws.services.kms.model.DecryptResult;
 import com.amazonaws.services.kms.model.GenerateDataKeyRequest;
@@ -47,29 +51,33 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 public class JCredStash {
-    protected AmazonDynamoDBClient amazonDynamoDBClient;
-    protected AWSKMSClient awskmsClient;
+    protected AmazonDynamoDB amazonDynamoDBClient;
+    protected AWSKMS awskmsClient;
     protected CredStashCrypto cryptoImpl;
     protected AWSSecurityTokenService awsSecurityTokenService;
     protected DynamoDB dynamoDB;
 
     protected JCredStash() {
-        this.amazonDynamoDBClient = new AmazonDynamoDBClient();
-        this.awskmsClient = new AWSKMSClient();
+        this.amazonDynamoDBClient = AmazonDynamoDBClientBuilder.defaultClient();
+        this.awskmsClient = AWSKMSClientBuilder.defaultClient();
         this.cryptoImpl = new CredStashBouncyCastleCrypto();
         this.awsSecurityTokenService = AWSSecurityTokenServiceClient.builder().withClientConfiguration(new ClientConfiguration()).build();
         this.dynamoDB = new DynamoDB(amazonDynamoDBClient);
     }
 
     protected JCredStash(AWSCredentialsProvider awsCredentialsProvider) {
-        this.amazonDynamoDBClient = new AmazonDynamoDBClient(awsCredentialsProvider);
-        this.awskmsClient = new AWSKMSClient(awsCredentialsProvider);
+        this.amazonDynamoDBClient = AmazonDynamoDBClientBuilder.standard()
+                .withCredentials(awsCredentialsProvider)
+                .build();
+        this.awskmsClient = AWSKMSClientBuilder.standard()
+                .withCredentials(awsCredentialsProvider)
+                .build();
         this.cryptoImpl = new CredStashBouncyCastleCrypto();
         this.awsSecurityTokenService = AWSSecurityTokenServiceClient.builder().withClientConfiguration(new ClientConfiguration()).build();
         this.dynamoDB = new DynamoDB(amazonDynamoDBClient);
     }
 
-    protected JCredStash(AmazonDynamoDBClient amazonDynamoDBClient, AWSKMSClient awskmsClient) {
+    protected JCredStash(AmazonDynamoDB amazonDynamoDBClient, AWSKMS awskmsClient) {
         this.amazonDynamoDBClient = amazonDynamoDBClient;
         this.awskmsClient = awskmsClient;
         this.cryptoImpl = new CredStashBouncyCastleCrypto();
@@ -77,7 +85,7 @@ public class JCredStash {
         this.dynamoDB = new DynamoDB(amazonDynamoDBClient);
     }
 
-    protected JCredStash(AmazonDynamoDBClient amazonDynamoDBClient, AWSKMSClient awskmsClient, AWSSecurityTokenService awsSecurityTokenService) {
+    protected JCredStash(AmazonDynamoDB amazonDynamoDBClient, AWSKMS awskmsClient, AWSSecurityTokenService awsSecurityTokenService) {
         this.amazonDynamoDBClient = amazonDynamoDBClient;
         this.awskmsClient = awskmsClient;
         this.cryptoImpl = new CredStashBouncyCastleCrypto();


### PR DESCRIPTION
- Updated bouncycastle version to be latest one (1.65)
- Updating Clients to use ClientBuilder (existing method is deprecated)
- Fixing FideliusClient to not force us-east-1 on user (will use default region provided instead)