### PR TITLE
Improve logging when failing to identify user role

### DIFF
--- a/fidelius-sdk/src/main/java/org/finra/fidelius/FideliusClient.java
+++ b/fidelius-sdk/src/main/java/org/finra/fidelius/FideliusClient.java
@@ -238,7 +238,7 @@ public class FideliusClient {
                 return userTokens[0];
             }
         } catch(Exception e){
-            logger.error(e.getLocalizedMessage());
+            logger.error("Failed to determine user: {}", ExceptionUtils.getStackTrace(e));
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
Previous failures could result in a blank error message.