### PR TITLE
Membership url oauth support

### DIFF
--- a/documentation/prequisites/configuration.md
+++ b/documentation/prequisites/configuration.md
@@ -70,3 +70,7 @@ Note: providing the following configuration will enable OAuth 2.0 for the API ca
  | fidelius.auth.oauth.clientSecret     | The Client Secret used when fetching the OAuth 2.0 token.             	                    | string 	|
  | fidelius.auth.oauth.tokenUrl         | The Endpoint Fidelius calls to fetch the OAuth 2.0 token.            	                        | string 	|
  | fidelius.auth.oauth.tokenUri         | The Endpoint URI Fidelius uses to fetch the OAuth 2.0 token.                                	| string 	|
+ | fidelius.rotate.oauth.clientId       | The Client ID used when fetching the OAuth 2.0 token for the secret rotation endpoint.        | string 	|
+ | fidelius.rotate.oauth.clientSecret   | The Client Secret used when fetching the OAuth 2.0 token for the secret rotation endpoint.    | string 	|
+ | fidelius.rotate.oauth.tokenUrl       | The Endpoint Fidelius calls to fetch the OAuth 2.0 token for the secret rotation endpoint.    | string 	|
+ | fidelius.rotate.oauth.tokenUri       | The Endpoint URI Fidelius uses to fetch the OAuth 2.0 token for the secret rotation endpoint. | string 	|

--- a/fidelius-service/src/main/java/org/finra/fidelius/services/CredentialsService.java
+++ b/fidelius-service/src/main/java/org/finra/fidelius/services/CredentialsService.java
@@ -104,16 +104,16 @@ public class CredentialsService {
     @Value("${fidelius.rotate.uri:}")
     private Optional<String> rotateUri;
 
-    @Value("${fidelius.auth.oauth.tokenUrl:}")
+    @Value("${fidelius.rotate.oauth.tokenUrl:}")
     private Optional<String> tokenUrl;
 
-    @Value("${fidelius.auth.oauth.tokenUri:}")
+    @Value("${fidelius.rotate.oauth.tokenUri:}")
     private Optional<String> tokenUri;
 
-    @Value("${fidelius.auth.oauth.clientId:}")
+    @Value("${fidelius.rotate.oauth.clientId:}")
     private Optional<String> clientId;
 
-    @Value("${fidelius.auth.oauth.clientSecret:}")
+    @Value("${fidelius.rotate.oauth.clientSecret:}")
     private Optional<String> clientSecret;
 
     private final static String RDS = "rds";

--- a/fidelius-service/src/main/java/org/finra/fidelius/services/MembershipService.java
+++ b/fidelius-service/src/main/java/org/finra/fidelius/services/MembershipService.java
@@ -17,13 +17,27 @@
 
 package org.finra.fidelius.services;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.dmfs.httpessentials.client.HttpRequestExecutor;
+import org.dmfs.httpessentials.httpurlconnection.HttpUrlConnectionExecutor;
+import org.dmfs.oauth2.client.*;
+import org.dmfs.oauth2.client.grants.ClientCredentialsGrant;
+import org.dmfs.oauth2.client.scope.BasicScope;
+import org.dmfs.rfc3986.encoding.Precoded;
+import org.dmfs.rfc3986.uris.LazyUri;
+import org.dmfs.rfc5545.Duration;
 import org.finra.fidelius.model.membership.Membership;
 import org.finra.fidelius.services.rest.RESTService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.inject.Inject;
+import java.net.URI;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 @Service
 public class MembershipService {
@@ -37,8 +51,8 @@ public class MembershipService {
     @Value("${fidelius.membership-server-uri}")
     protected String membershipServerUri;
 
-    public List<String> getAllMemberships() {
-        Membership memberships = restService.makeCall(membershipServerUrl, membershipServerUri, Membership.class);
+    public List<String> getAllMemberships(String userName) {
+        Membership memberships = restService.makeCall(membershipServerUrl, membershipServerUri, Membership.class, userName);
         memberships.getMemberships().replaceAll(String::toUpperCase);
 
         return memberships.getMemberships();

--- a/fidelius-service/src/main/java/org/finra/fidelius/services/auth/FideliusRoleService.java
+++ b/fidelius-service/src/main/java/org/finra/fidelius/services/auth/FideliusRoleService.java
@@ -65,7 +65,7 @@ public class FideliusRoleService {
             .expireAfterWrite(10L, TimeUnit.MINUTES)
             .build(new CacheLoader<String, Optional<List<String>>>() {
                 public Optional<List<String>> load(String userName) throws Exception {
-                    return Optional.ofNullable(loadLdapUserMasterMemberships());
+                    return Optional.ofNullable(loadLdapUserMasterMemberships(userName));
                 }
             });
 
@@ -75,7 +75,7 @@ public class FideliusRoleService {
             .expireAfterWrite(10L, TimeUnit.MINUTES)
             .build(new CacheLoader<String, Optional<List<String>>>() {
                 public Optional<List<String>> load(String userName) throws Exception {
-                    return Optional.ofNullable(loadLdapUserOpsMemberships());
+                    return Optional.ofNullable(loadLdapUserOpsMemberships(userName));
                 }
             });
 
@@ -185,13 +185,13 @@ public class FideliusRoleService {
         return accountService.getAccountByAlias(accountAlias).getAccountId();
     }
 
-    private List<String> loadLdapUserMasterMemberships(){
+    private List<String> loadLdapUserMasterMemberships(String userName){
         List<String> memberships = new ArrayList<>();
         fideliusAuthorizationService.getMasterMemberships(masterPattern, opsPattern).forEach((membership) -> {
             Matcher m = masterPattern.matcher(membership);
             if(m.find()) {
                 try {
-                    memberships.addAll(membershipService.getAllMemberships());
+                    memberships.addAll(membershipService.getAllMemberships(userName));
                 } catch(Exception e) {
                     logger.error("Error getting Master role memberships", e);
                     e.printStackTrace();
@@ -201,13 +201,13 @@ public class FideliusRoleService {
         return memberships;
     }
 
-    private List<String> loadLdapUserOpsMemberships(){
+    private List<String> loadLdapUserOpsMemberships(String userName){
         List<String> memberships = new ArrayList<>();
         fideliusAuthorizationService.getOpsMemberships(masterPattern, opsPattern).forEach((membership) -> {
             Matcher m = opsPattern.matcher(membership);
             if(m.find()) {
                 try {
-                    memberships.addAll(membershipService.getAllMemberships());
+                    memberships.addAll(membershipService.getAllMemberships(userName));
                 } catch(Exception e) {
                     logger.error("Error getting Ops role memberships", e);
                     e.printStackTrace();

--- a/fidelius-service/src/main/java/org/finra/fidelius/services/rest/RESTService.java
+++ b/fidelius-service/src/main/java/org/finra/fidelius/services/rest/RESTService.java
@@ -17,15 +17,125 @@
 
 package org.finra.fidelius.services.rest;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.dmfs.httpessentials.client.HttpRequestExecutor;
+import org.dmfs.httpessentials.httpurlconnection.HttpUrlConnectionExecutor;
+import org.dmfs.oauth2.client.*;
+import org.dmfs.oauth2.client.grants.ClientCredentialsGrant;
+import org.dmfs.oauth2.client.scope.BasicScope;
+import org.dmfs.rfc3986.encoding.Precoded;
+import org.dmfs.rfc3986.uris.LazyUri;
+import org.dmfs.rfc5545.Duration;
+import org.finra.fidelius.services.CredentialsService;
+import org.finra.fidelius.services.auth.FideliusRoleService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import javax.inject.Inject;
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
 @Component
 public class RESTService {
+
+    @Value("${fidelius.auth.oauth.clientId:}")
+    private Optional<String> clientId;
+
+    @Value("${fidelius.auth.oauth.clientSecret:}")
+    private Optional<String> clientSecret;
+
+    @Value("${fidelius.auth.oauth.tokenUrl:}")
+    private Optional<String> tokenUrl;
+
+    @Value("${fidelius.auth.oauth.tokenUri:}")
+    private Optional<String> tokenUri;
+
+    private Logger logger = LoggerFactory.getLogger(RESTService.class);
+
+    private LoadingCache<String, Optional<String>> userOAuth2TokenCache = CacheBuilder.newBuilder()
+            .maximumSize(1000L)
+            .concurrencyLevel(10)
+            .expireAfterWrite(60L, TimeUnit.MINUTES)
+            .build(new CacheLoader<String, Optional<String>>() {
+                public Optional<String> load(String user) throws Exception {
+                    return Optional.ofNullable(getOAuth2Header(clientId.get(), clientSecret.get()));
+                }
+            });
 
     public <T> T makeCall(String url, String uri, Class<T> clazz) {
         RestTemplate restTemplate = new RestTemplate();
         String completeUrl = String.format("%s/%s", url, uri);
         return restTemplate.getForObject(completeUrl, clazz);
+    }
+
+    public <T> T makeCall(String url, String uri, Class<T> clazz, String userName) {
+        if(oAuth2ConfigProvided()) {
+            logger.info("OAuth config detected. Fetching token.");
+            String bearerToken = getOAuth2Token(userName);
+            return makeCallWithOAuthToken(url, uri, clazz, bearerToken);
+        }
+        return makeCall(url, uri, clazz);
+    }
+
+    public <T> T makeCallWithOAuthToken(String url, String uri, Class<T> clazz, String bearerToken) {
+        RestTemplate restTemplate = new RestTemplate();
+        String completeUrl = String.format("%s/%s", url, uri);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", bearerToken);
+        HttpEntity<T> requestEntity = new HttpEntity<>(headers);
+        return restTemplate.exchange(completeUrl, HttpMethod.GET, requestEntity, clazz).getBody();
+    }
+
+    private String getOAuth2Header(String username, String password) {
+        String token = getOAuth2Token(username, password);
+        if(token.isEmpty()) {
+            logger.error("Unable to fetch access token.");
+            return "";
+        }
+        logger.info("Access token fetched.");
+        return String.format("Bearer %s", token);
+    }
+
+    private String getOAuth2Token(String username, String password) {
+        HttpRequestExecutor executor = new HttpUrlConnectionExecutor();
+        // Create OAuth2 provider
+        OAuth2AuthorizationProvider provider = new BasicOAuth2AuthorizationProvider(
+                URI.create(tokenUrl.get() + "/" + tokenUri.get()),
+                URI.create(tokenUrl.get() + "/" + tokenUri.get()),
+                new Duration(1,0,600)           //Default expiration time if server does not respond
+        );
+        // Create OAuth2 client credentials
+        OAuth2ClientCredentials credentials = new BasicOAuth2ClientCredentials(username, password);
+        //Create OAuth2 client
+        OAuth2Client client = new BasicOAuth2Client(
+                provider,
+                credentials,
+                new LazyUri(new Precoded("http://localhost"))
+        );
+        try {
+            OAuth2AccessToken token = new ClientCredentialsGrant(client, new BasicScope("scope")).accessToken(executor);
+            return token.accessToken().toString();
+        } catch(Exception e) {
+            logger.error("Exception occurred while fetching access token.");
+        }
+        return "";
+    }
+
+    public String getOAuth2Token(String user) {
+        return userOAuth2TokenCache.getUnchecked(user).get();
+    }
+
+    public boolean oAuth2ConfigProvided() {
+        return clientId.isPresent() && clientSecret.isPresent() && tokenUrl.isPresent() && tokenUri.isPresent()
+                && !clientId.get().equals("") && !clientSecret.get().equals("") && !tokenUrl.get().equals("") && !tokenUri.get().equals("");
     }
 }

--- a/fidelius-service/src/test/java/org/finra/fidelius/services/MembershipServiceTest.java
+++ b/fidelius-service/src/test/java/org/finra/fidelius/services/MembershipServiceTest.java
@@ -68,9 +68,9 @@ public class MembershipServiceTest {
 
         when(restService.makeCall(any(), any(), any())).thenReturn(response);
 
-        Assert.assertTrue(membershipService.getAllMemberships().contains("APPLICATION1"));
-        Assert.assertTrue(membershipService.getAllMemberships().contains("APPLICATION2"));
-        Assert.assertTrue(membershipService.getAllMemberships().contains("APPLICATION3"));
+        Assert.assertTrue(membershipService.getAllMemberships("testUser").contains("APPLICATION1"));
+        Assert.assertTrue(membershipService.getAllMemberships("testUser").contains("APPLICATION2"));
+        Assert.assertTrue(membershipService.getAllMemberships("testUser").contains("APPLICATION3"));
 
     }
 
@@ -79,7 +79,7 @@ public class MembershipServiceTest {
 
         when(restService.makeCall(any(), any(), any())).thenReturn(new Membership());
 
-        Assert.assertTrue(membershipService.getAllMemberships().size() == 0);
+        Assert.assertTrue(membershipService.getAllMemberships("testUser").size() == 0);
 
     }
 }


### PR DESCRIPTION
- OAuth2.0 is now (optionally) supported for fetching memberships via fidelius.membership-server-url and fidelius.membership-server-uri
- Tested for backward compatibility (no OAuth config for fetching user memberships).