### PR TITLE
Fix for app teams sometimes seeing others' credentials listed

### DIFF
--- a/fidelius-service/src/main/java/org/finra/fidelius/services/aws/DynamoDBService.java
+++ b/fidelius-service/src/main/java/org/finra/fidelius/services/aws/DynamoDBService.java
@@ -55,7 +55,7 @@ public class DynamoDBService {
             try {
                 DynamoDbTable<CredentialSchema> credentialTable = dynamoDbEnhancedClient.table(tableName, TableSchema.fromBean(CredentialSchema.class));
                 for (CredentialSchema rec : credentialTable.scan().items()) {
-                    if(rec.getName().startsWith(application)) {
+                    if(rec.getName().startsWith(application + ".")) {
                         queryResults.add(rec.getMapOfAttributeValues());
                     }
                 }


### PR DESCRIPTION
Was able to reproduce the bug locally and fix it. Unit tests should require no changes.