### PR TITLE
Removed metadata validation for service accounts

### DIFF
--- a/fidelius-service/src/main/java/org/finra/fidelius/services/CredentialsService.java
+++ b/fidelius-service/src/main/java/org/finra/fidelius/services/CredentialsService.java
@@ -670,20 +670,11 @@ public class CredentialsService {
             case "Aurora":
             case "DocumentDB":
             case "Redshift":
-                return "";
             case "Service Account":
-                if(!metadata.getSource().startsWith("svc_"+metadata.getApplication().toLowerCase())){
-                    return "Service Account sources must start with \"svc_" + metadata.getApplication().toLowerCase() + "\"";
-                }
-                String accountSuffix = accountsService.getAccountByAlias(metadata.getAccount()).getSdlc().toLowerCase().substring(0,1);
-                if(!metadata.getSource().endsWith("_"+accountSuffix)){
-                    return "Service Account sources must end with \"_" + accountSuffix + "\" in " + metadata.getAccount();
-                }
-                break;
+                return "";
             default:
                 return metadata.getSourceType() + " is an unsupported metadata source type.";
         }
-        return "";
     }
 
     private String splitRoleARN(AttributeValue roleARN) {


### PR DESCRIPTION
This validation is too FINRA-specific. We can manage this in the password rotation service.